### PR TITLE
Fix qmake error.

### DIFF
--- a/Viqo.pro
+++ b/Viqo.pro
@@ -29,8 +29,7 @@ SOURCES += src/main.cpp\
     src/NicoLiveManager/Alert/alert.cpp \
     src/NicoLiveManager/Alert/wakutcp.cpp
 
-HEADERS  += src/main.h\
-    src/NicoLiveManager/nicolivemanager.h \
+HEADERS  += src/NicoLiveManager/nicolivemanager.h \
     src/commtcp.h \
     src/cookieread.h \
     src/livedata.h \


### PR DESCRIPTION
こんにちは。
Viqoをcloneしてqmakeすると src/main.hがない！と怒られましたので、
修正してみました。qmake & make 並びに qtcreatorでコンパイルできる
ことはこちらの環境で確認しています。

もしよろしければと思い、pull requestしてみました。

以下、私の環境です。

```
$ uname -a
Linux yukke-main 3.15.5.yukke.org #1 SMP Sat Jul 12 11:52:07 JST 2014 x86_64 GNU/Linux

$ qmake -v
QMake version 3.0
Using Qt version 5.3.1 in /usr/lib/x86_64-linux-gnu

$ gcc --version
gcc (Debian 4.9.0-10) 4.9.0
```

追記:

コマンドラインからは、以下の手順でビルドできました。

```
$ sudo apt-get install qt5関連の開発パッケージ
$ git clone https://github.com/diginatu/Viqo.git
$ cd Viqo
$ qmake
$ make
```
