### PR TITLE
コマンドに渡すときのエスケープを3連続ダブルクォートに変更

### DIFF
--- a/src/NicoLiveManager/LiveWaku/commtcp.cpp
+++ b/src/NicoLiveManager/LiveWaku/commtcp.cpp
@@ -160,7 +160,7 @@ void CommTcp::readOneRawComment(const QString rawcomm)
     QString cmd = mwin->settings.getCommandComment();
 
     QString escmd = comm;
-    escmd.replace("'", "");
+    escmd.replace("\"", "\"\"\"");
     cmd.replace("%comment%",escmd);
 
     pr.start(cmd);

--- a/src/NicoLiveManager/LiveWaku/livewaku.cpp
+++ b/src/NicoLiveManager/LiveWaku/livewaku.cpp
@@ -132,7 +132,9 @@ void LiveWaku::playerStatusFinished(QNetworkReply* reply)
     QProcess pr;
     QString cmd = mwin->settings.getCommandNewWaku();
 
-    cmd.replace("%newTitle%", title);
+    QString estitle = title;
+    estitle.replace("\"", "\"\"\"");
+    cmd.replace("%newTitle%", estitle);
 
     pr.start(cmd);
     pr.waitForFinished(5000);


### PR DESCRIPTION
QtのソースをみるとQProccess::startに渡した文字列を分解しているparseCombinedArgStringで
```
// handle quoting. tokens can be surrounded by double quotes
// "hello world". three consecutive double quotes represent
// the quote character itself.
```
とありました。
つまり、コマンドに分解するときに""" -> "になるので、コメント等に含まれる"を"""に
しておけば、うまく動作すると思われます。たぶん。
一応、テストはしました。

もともとのシングルクォートの削除は無意味っぽかったんで、削除してます。